### PR TITLE
Refactor to wrap BundleStats in EnhancedBundleStats

### DIFF
--- a/package/src/analysis/analyzeBundleGroup.ts
+++ b/package/src/analysis/analyzeBundleGroup.ts
@@ -1,10 +1,10 @@
-import { BundleStats, Chunk, ChunkGroup, ChunkId } from 'webpack-bundle-stats-plugin';
-import { getChunkGroupMap } from '../utils/getChunkGroupMap';
-import { getChunkMap } from '../utils/getChunkMap';
+import { Chunk, ChunkGroup, ChunkId } from 'webpack-bundle-stats-plugin';
+import { EnhancedBundleStats } from '../enhanced-bundle-stats/EnhancedBundleStats';
 
-export function analyzeBundleGroup(stats: BundleStats, chunkGroupIds: string[]): BundleAnalysis {
-    const chunkGroupMap = getChunkGroupMap(stats);
-    const chunkMap = getChunkMap(stats);
+export function analyzeBundleGroup(
+    stats: EnhancedBundleStats,
+    chunkGroupIds: string[]
+): BundleAnalysis {
     const bundleDetails: BundleGroupDetails[] = [];
 
     // Keep track of assets that are loaded as each bundle loads; only the first time an asset
@@ -23,7 +23,7 @@ export function analyzeBundleGroup(stats: BundleStats, chunkGroupIds: string[]):
 
     // Process each bundle in order
     for (let chunkGroupId of chunkGroupIds) {
-        const chunkGroup = chunkGroupMap.get(chunkGroupId)!;
+        const chunkGroup = stats.getChunkGroup(chunkGroupId)!;
 
         // Track the size of the bundle assets (netAssetSize excludes any that have already been
         // downloaded as part of an earlier bundle).  This also tracks duplcated code per asset
@@ -37,12 +37,12 @@ export function analyzeBundleGroup(stats: BundleStats, chunkGroupIds: string[]):
 
         // Process each chunk in the bundle
         for (let chunkId of chunkGroup.chunks) {
-            const chunk = chunkMap.get(chunkId)!;
+            const chunk = stats.getChunk(chunkId)!;
             const jsAsset = getJsAsset(chunk);
 
             // Accumulate chunk assets
             for (const filename of chunk.files) {
-                const addedSize = loadedAssets.has(filename) ? 0 : stats.assets[filename].size;
+                const addedSize = loadedAssets.has(filename) ? 0 : stats.getAsset(filename).size;
                 assetDetails.set(filename, { netSize: addedSize, duplicatedCode: new Map() });
                 loadedAssets.add(filename);
                 netAssetSize += addedSize;

--- a/package/src/analysis/analyzeBundles.ts
+++ b/package/src/analysis/analyzeBundles.ts
@@ -1,12 +1,15 @@
 import { BundleStats } from 'webpack-bundle-stats-plugin';
 import { analyzeBundleGroup } from './analyzeBundleGroup';
+import { EnhancedBundleStats } from '../enhanced-bundle-stats/EnhancedBundleStats';
 
 export function analyzeBundles(stats: BundleStats, bundleNames?: string[]) {
+    const enhancedBundleStats = new EnhancedBundleStats(stats);
+
     const chunkGroupIds = bundleNames
         ? getChunkGroupIds(stats, bundleNames)
-        : getAllChunkGroupIds(stats);
+        : getAllChunkGroupIds(enhancedBundleStats);
 
-    return analyzeBundleGroup(stats, chunkGroupIds);
+    return analyzeBundleGroup(enhancedBundleStats, chunkGroupIds);
 }
 
 function getChunkGroupIds(stats: BundleStats, bundleNames: string[]) {
@@ -27,6 +30,6 @@ function getBundleIdFromName(stats: BundleStats, bundleName: string) {
     return filteredChunkGroups[0].id;
 }
 
-function getAllChunkGroupIds(stats: BundleStats) {
-    return [...new Set(stats.chunkGroups.map(cg => cg.id))];
+function getAllChunkGroupIds(stats: EnhancedBundleStats) {
+    return stats.getChunkGroups().map(cg => cg.id);
 }

--- a/package/src/bundle-graph-explorer/addChunkGroupToGraph.ts
+++ b/package/src/bundle-graph-explorer/addChunkGroupToGraph.ts
@@ -5,7 +5,7 @@ import { GraphData } from './getGraphData';
 export function addChunkGroupToGraph(graphData: GraphData, chunkGroupId: string, parentId: string) {
     const nodes = graphData.visData.nodes as DataSet<Node>;
     const edges = graphData.visData.edges as DataSet<Edge>;
-    const chunkGroup = graphData.chunkGroupMap.get(chunkGroupId)!;
+    const chunkGroup = graphData.stats.getChunkGroup(chunkGroupId)!;
 
     // Add the node
     if (!nodes.get(chunkGroupId)) {
@@ -18,7 +18,7 @@ export function addChunkGroupToGraph(graphData: GraphData, chunkGroupId: string,
     // Fill in edges to/from this node
     nodes.forEach(node => {
         const otherChunkGroupId = node.id! as string;
-        const otherChunkGroup = graphData.chunkGroupMap.get(otherChunkGroupId)!;
+        const otherChunkGroup = graphData.stats.getChunkGroup(otherChunkGroupId)!;
 
         // Check for edge from parent
         if (otherChunkGroup.children.includes(chunkGroupId)) {

--- a/package/src/bundle-graph-explorer/components/ChildBundleList.tsx
+++ b/package/src/bundle-graph-explorer/components/ChildBundleList.tsx
@@ -18,15 +18,15 @@ export const ChildBundleList: React.FC<ChildBundleListProps> = props => {
             return [];
         }
 
-        const chunkGroup = data.chunkGroupMap.get(selectedNode)!;
+        const chunkGroup = data.stats.getChunkGroup(selectedNode)!;
 
         // Filter out duplicate children
         const childIds = [...new Set(chunkGroup.children)];
 
         // Sort by name first, then ID
         childIds.sort((a, b) => {
-            const a2 = data.chunkGroupMap.get(a)!;
-            const b2 = data.chunkGroupMap.get(b)!;
+            const a2 = data.stats.getChunkGroup(a)!;
+            const b2 = data.stats.getChunkGroup(b)!;
             if (a2.name) {
                 return b2.name ? a2.name.localeCompare(b2.name) : -1;
             } else {
@@ -52,7 +52,7 @@ export const ChildBundleList: React.FC<ChildBundleListProps> = props => {
                 {childIds.map(c => (
                     <ChildBundle
                         key={c}
-                        chunkGroup={data!.chunkGroupMap.get(c)!}
+                        chunkGroup={data!.stats.getChunkGroup(c)!}
                         isInGraph={nodesInGraph.includes(c)}
                         onClick={onClick}
                     />

--- a/package/src/bundle-graph-explorer/getEntryBundles.ts
+++ b/package/src/bundle-graph-explorer/getEntryBundles.ts
@@ -1,7 +1,9 @@
-import type { ChunkGroupMap } from '../utils/getChunkGroupMap';
+import { EnhancedBundleStats } from '../enhanced-bundle-stats/EnhancedBundleStats';
 
-export function getEntryBundles(chunkGroupMap: ChunkGroupMap) {
-    return [...chunkGroupMap.values()].filter(
-        cg => cg.chunkGroupType === 'Entrypoint' && cg.name && !cg.name.includes('node_modules')
-    );
+export function getEntryBundles(stats: EnhancedBundleStats) {
+    return stats
+        .getChunkGroups()
+        .filter(
+            cg => cg.chunkGroupType === 'Entrypoint' && cg.name && !cg.name.includes('node_modules')
+        );
 }

--- a/package/src/bundle-graph-explorer/getGraphData.ts
+++ b/package/src/bundle-graph-explorer/getGraphData.ts
@@ -1,18 +1,17 @@
 import { Data, Edge, Node } from 'vis-network';
 import { DataSet } from 'vis-data';
-import { BundleStats, ChunkGroup } from 'webpack-bundle-stats-plugin';
-import { getChunkGroupMap } from '../utils/getChunkGroupMap';
+import { BundleStats } from 'webpack-bundle-stats-plugin';
 import { getEntryBundles } from './getEntryBundles';
+import { EnhancedBundleStats } from '../enhanced-bundle-stats/EnhancedBundleStats';
 
 export interface GraphData {
-    chunkGroupMap: Map<string, ChunkGroup>;
-    stats: BundleStats;
+    stats: EnhancedBundleStats;
     visData: Data;
 }
 
 export function getGraphData(stats: BundleStats): GraphData {
-    const chunkGroupMap = getChunkGroupMap(stats);
-    const entryBundles = getEntryBundles(chunkGroupMap);
+    const enhancedStats = new EnhancedBundleStats(stats);
+    const entryBundles = getEntryBundles(enhancedStats);
 
     const initialNodes = [...entryBundles].map<Node>(cg => ({
         id: cg.id,
@@ -24,8 +23,7 @@ export function getGraphData(stats: BundleStats): GraphData {
     nodes.add(initialNodes);
 
     return {
-        chunkGroupMap,
-        stats,
+        stats: enhancedStats,
         visData: { nodes, edges },
     };
 }

--- a/package/src/enhanced-bundle-stats/EnhancedBundleStats.ts
+++ b/package/src/enhanced-bundle-stats/EnhancedBundleStats.ts
@@ -1,0 +1,37 @@
+import { BundleStats, ChunkId } from 'webpack-bundle-stats-plugin';
+import { ChunkGroupMap, createChunkGroupMap } from './createChunkGroupMap';
+import { ChunkMap, createChunkMap } from './createChunkMap';
+
+export class EnhancedBundleStats {
+    private chunkMap: ChunkMap;
+    private chunkGroupMap: ChunkGroupMap;
+
+    constructor(public stats: BundleStats) {
+        this.chunkMap = createChunkMap(stats);
+        this.chunkGroupMap = createChunkGroupMap(stats);
+    }
+
+    getAsset(filename: string) {
+        return this.stats.assets[filename];
+    }
+
+    hasChunk(id: ChunkId) {
+        return this.chunkMap.has(id);
+    }
+
+    getChunk(id: ChunkId) {
+        return this.chunkMap.get(id);
+    }
+
+    hasChunkGroup(id: string) {
+        return this.chunkGroupMap.has(id);
+    }
+
+    getChunkGroup(id: string) {
+        return this.chunkGroupMap.get(id);
+    }
+
+    getChunkGroups() {
+        return [...this.chunkGroupMap.values()];
+    }
+}

--- a/package/src/enhanced-bundle-stats/createChunkGroupMap.ts
+++ b/package/src/enhanced-bundle-stats/createChunkGroupMap.ts
@@ -3,7 +3,7 @@ import { BundleStats, ChunkGroup } from 'webpack-bundle-stats-plugin';
 
 export type ChunkGroupMap = Map<string, ChunkGroup>;
 
-export function getChunkGroupMap(stats: BundleStats): ChunkGroupMap {
+export function createChunkGroupMap(stats: BundleStats) {
     const chunkGroupMap: ChunkGroupMap = new Map();
     for (let cg of stats.chunkGroups) {
         if (chunkGroupMap.has(cg.id)) {

--- a/package/src/enhanced-bundle-stats/createChunkMap.ts
+++ b/package/src/enhanced-bundle-stats/createChunkMap.ts
@@ -1,7 +1,9 @@
 import { BundleStats, Chunk, ChunkId } from 'webpack-bundle-stats-plugin';
 
-export function getChunkMap(stats: BundleStats) {
-    const chunkMap = new Map<ChunkId, Chunk>();
+export type ChunkMap = Map<ChunkId, Chunk>;
+
+export function createChunkMap(stats: BundleStats) {
+    const chunkMap: ChunkMap = new Map();
     for (let chunk of stats.chunks) {
         chunkMap.set(chunk.id, chunk);
     }


### PR DESCRIPTION
This should simplify future code; the idea is that we'll pass `EnhancedBundleStats` around everywhere, and it will encapsulate a bunch of common utilities like getting chunks or chunk groups by ID.