### PR TITLE
Implement getBundlesFromAssets

### DIFF
--- a/package/src/analysis/getBundlesFromAssets.ts
+++ b/package/src/analysis/getBundlesFromAssets.ts
@@ -1,0 +1,60 @@
+import { BundleStats } from 'webpack-bundle-stats-plugin';
+import { EnhancedBundleStats } from '../enhanced-bundle-stats/EnhancedBundleStats';
+
+// Given a set of assets, makes a best effort to determine what bundles were loaded
+export function getBundlesFromAssets(stats: BundleStats, assets: string[]) {
+    const enhancedStats = new EnhancedBundleStats(stats);
+    const assetToBundleMap = createAssetToBundleMap(enhancedStats);
+
+    const bundles = new Set<string>();
+    const unknownAssets = new Set<string>();
+
+    // Look for assets that are only in one bundle
+    for (let asset of assets) {
+        const assetBundles = assetToBundleMap.get(asset);
+        if (!assetBundles) {
+            unknownAssets.add(asset);
+        } else if (assetBundles.size === 1) {
+            bundles.add(assetBundles.values().next().value);
+        }
+    }
+
+    // Figure out which assets are leftover after accounting for the bundles we know about
+    const leftoverAssets = new Set<string>(assets);
+    for (let chunkGroupId of bundles) {
+        const chunkGroup = enhancedStats.getChunkGroup(chunkGroupId)!;
+        for (let chunkId of chunkGroup.chunks) {
+            const chunk = enhancedStats.getChunk(chunkId)!;
+            for (let asset of chunk.files) {
+                if (leftoverAssets.has(asset)) {
+                    leftoverAssets.delete(asset);
+                }
+            }
+        }
+    }
+
+    return {
+        bundles: [...bundles].map(id => enhancedStats.getChunkGroup(id)),
+        leftoverAssets,
+        unknownAssets,
+    };
+}
+
+function createAssetToBundleMap(stats: EnhancedBundleStats) {
+    const assetToBundleMap = new Map<string, Set<string>>();
+
+    for (let chunkGroup of stats.getChunkGroups()) {
+        for (let chunkId of chunkGroup.chunks) {
+            const chunk = stats.getChunk(chunkId)!;
+            for (let asset of chunk?.files) {
+                if (!assetToBundleMap.has(asset)) {
+                    assetToBundleMap.set(asset, new Set());
+                }
+
+                assetToBundleMap.get(asset)!.add(chunkGroup.id);
+            }
+        }
+    }
+
+    return assetToBundleMap;
+}

--- a/package/src/index.node.ts
+++ b/package/src/index.node.ts
@@ -1,2 +1,3 @@
 // Utilities
 export { analyzeBundles } from './analysis/analyzeBundles';
+export { getBundlesFromAssets } from './analysis/getBundlesFromAssets';

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -6,3 +6,4 @@ export {
 
 // Utilities
 export { analyzeBundles } from './analysis/analyzeBundles';
+export { getBundlesFromAssets } from './analysis/getBundlesFromAssets';


### PR DESCRIPTION
Implement `getBundlesFromAssets`, which, given a list of assets, will return information about what bundles they come from.  This could be used, for instance, if you record all scripts that get loaded when booting an app, to determine which bundles are needed during boot.

The returned object has several properties:
- `bundles` — bundles that we know for sure are loaded
- `leftoverAssets` — assets that were loaded, but can't be pinpointed to a specific bundle; maybe because only a partial bundle was loaded for some reason
- `unknownAssets` — assets that were loaded but don't show up as part of any bundle