### PR TITLE
Add mode selection to sample app

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     "vis-data": "^7.1.4",
     "vis-network": "^9.1.2",
     "web-vitals": "^2.1.4",
-    "webpack-bundle-insights": "0.1.1"
+    "webpack-bundle-insights": "*"
   },
   "devDependencies": {
     "webpack-bundle-diff": "^1.1.0",

--- a/app/src/app/App.css
+++ b/app/src/app/App.css
@@ -1,3 +1,9 @@
 body {
     margin: 0;
 }
+
+.selector {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+}

--- a/app/src/app/App.css
+++ b/app/src/app/App.css
@@ -1,25 +1,3 @@
 body {
     margin: 0;
 }
-
-.container {
-    position: relative;
-    min-height: 100vh;
-}
-
-.sidebar {
-    position: absolute;
-    top: 0;
-    left: 0;
-    background-color: rgba(255, 255, 255, 0.5);
-    border: 1px solid #aaaaaa;
-    z-index: 1;
-}
-
-.graph {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-}

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -1,13 +1,20 @@
+import React from 'react';
 import { BundleGraphExplorerPane } from './BundleGraphExplorerPane';
 import './App.css';
 
 export const App: React.FC<{}> = () => {
+    const [mode, setMode] = React.useState('none');
+
+    const onSelectMode = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        setMode(event.target.value);
+    };
+
     return (
         <>
-            <BundleGraphExplorerPane />
-            <select className="selector">
-                <option>Hi</option>
-                <option>Bye</option>
+            {mode == 'explore' ? <BundleGraphExplorerPane /> : null}
+            <select className="selector" onChange={onSelectMode}>
+                <option value="none">Select mode</option>
+                <option value="explore">Bundle graph explorer</option>
             </select>
         </>
     );

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -2,5 +2,13 @@ import { BundleGraphExplorerPane } from './BundleGraphExplorerPane';
 import './App.css';
 
 export const App: React.FC<{}> = () => {
-    return <BundleGraphExplorerPane />;
+    return (
+        <>
+            <BundleGraphExplorerPane />
+            <select className="selector">
+                <option>Hi</option>
+                <option>Bye</option>
+            </select>
+        </>
+    );
 };

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -1,26 +1,6 @@
-import React from 'react';
-import { BundleStats } from 'webpack-bundle-stats-plugin';
-import { BundleGraphExplorer } from 'webpack-bundle-insights';
-import { StatsPicker } from '../components/StatsPicker';
+import { BundleGraphExplorerPane } from './BundleGraphExplorerPane';
 import './App.css';
 
 export const App: React.FC<{}> = () => {
-    const [stats, setStats] = React.useState<BundleStats>();
-
-    const onFileChanged = (stats: BundleStats) => {
-        if ((stats as any).bundleDataV2) {
-            stats = (stats as any).bundleDataV2;
-        }
-
-        setStats(stats);
-    };
-
-    return (
-        <div className="container">
-            <div className="sidebar">
-                <StatsPicker onFileChanged={onFileChanged} />
-            </div>
-            <BundleGraphExplorer stats={stats} className="graph" />
-        </div>
-    );
+    return <BundleGraphExplorerPane />;
 };

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -11,7 +11,7 @@ export const App: React.FC<{}> = () => {
 
     return (
         <>
-            {mode == 'explore' ? <BundleGraphExplorerPane /> : null}
+            {mode === 'explore' ? <BundleGraphExplorerPane /> : null}
             <select className="selector" onChange={onSelectMode}>
                 <option value="none">Select mode</option>
                 <option value="explore">Bundle graph explorer</option>

--- a/app/src/app/BundleGraphExplorerPane.css
+++ b/app/src/app/BundleGraphExplorerPane.css
@@ -3,9 +3,9 @@
     min-height: 100vh;
 }
 
-.sidebar {
+.picker {
     position: absolute;
-    top: 0;
+    bottom: 0;
     left: 0;
     background-color: rgba(255, 255, 255, 0.5);
     border: 1px solid #aaaaaa;

--- a/app/src/app/BundleGraphExplorerPane.css
+++ b/app/src/app/BundleGraphExplorerPane.css
@@ -1,0 +1,21 @@
+.container {
+    position: relative;
+    min-height: 100vh;
+}
+
+.sidebar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: rgba(255, 255, 255, 0.5);
+    border: 1px solid #aaaaaa;
+    z-index: 1;
+}
+
+.graph {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+}

--- a/app/src/app/BundleGraphExplorerPane.css
+++ b/app/src/app/BundleGraphExplorerPane.css
@@ -5,8 +5,8 @@
 
 .picker {
     position: absolute;
-    bottom: 0;
-    left: 0;
+    top: 25px;
+    left: 2px;
     background-color: rgba(255, 255, 255, 0.5);
     border: 1px solid #aaaaaa;
     z-index: 1;

--- a/app/src/app/BundleGraphExplorerPane.tsx
+++ b/app/src/app/BundleGraphExplorerPane.tsx
@@ -17,7 +17,7 @@ export const BundleGraphExplorerPane: React.FC<{}> = () => {
 
     return (
         <div className="container">
-            <div className="sidebar">
+            <div className="picker">
                 <StatsPicker onFileChanged={onFileChanged} />
             </div>
             <BundleGraphExplorer stats={stats} className="graph" />

--- a/app/src/app/BundleGraphExplorerPane.tsx
+++ b/app/src/app/BundleGraphExplorerPane.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { BundleStats } from 'webpack-bundle-stats-plugin';
+import { BundleGraphExplorer } from 'webpack-bundle-insights';
+import { StatsPicker } from '../components/StatsPicker';
+import './BundleGraphExplorerPane.css';
+
+export const BundleGraphExplorerPane: React.FC<{}> = () => {
+    const [stats, setStats] = React.useState<BundleStats>();
+
+    const onFileChanged = (stats: BundleStats) => {
+        if ((stats as any).bundleDataV2) {
+            stats = (stats as any).bundleDataV2;
+        }
+
+        setStats(stats);
+    };
+
+    return (
+        <div className="container">
+            <div className="sidebar">
+                <StatsPicker onFileChanged={onFileChanged} />
+            </div>
+            <BundleGraphExplorer stats={stats} className="graph" />
+        </div>
+    );
+};


### PR DESCRIPTION
This refactors the app to add a mode selector.  Currently there's a just one mode (bundle graph explorer) but this will allow for easily testing other components in the sample app.